### PR TITLE
Wallet provider rework

### DIFF
--- a/.changeset/calm-tigers-decide.md
+++ b/.changeset/calm-tigers-decide.md
@@ -1,0 +1,5 @@
+---
+"ethereal-react": minor
+---
+
+Add `noFallback` prop to the WalletProvider.

--- a/.changeset/good-poets-rule.md
+++ b/.changeset/good-poets-rule.md
@@ -1,0 +1,5 @@
+---
+"ethereal-react": patch
+---
+
+Expose new `useWalletConnected` hook.

--- a/.changeset/tame-dodos-prove.md
+++ b/.changeset/tame-dodos-prove.md
@@ -1,0 +1,5 @@
+---
+"ethereal-react": patch
+---
+
+Add new `loading` prop to the `WalletProvider` to allow a different node to be rendered while the wallet initializes.

--- a/.changeset/yellow-papayas-rest.md
+++ b/.changeset/yellow-papayas-rest.md
@@ -1,0 +1,5 @@
+---
+"ethereal-react": minor
+---
+
+Rename `useLogout` hook to `useDisconnectWallet`.

--- a/packages/ethereal-react/src/index.ts
+++ b/packages/ethereal-react/src/index.ts
@@ -2,8 +2,9 @@ export { useProvider, Provider } from "./provider";
 export {
   useConnectToWallet,
   WalletProvider,
-  useLogout,
+  useDisconnectWallet,
   useWeb3Modal,
+  useWalletConnected
 } from "./wallet";
 export { useContract, useReadContract, useWriteContract } from "./contracts";
 export { useUserAddress, useBalance } from "./accounts";

--- a/packages/example/src/pages/_app.tsx
+++ b/packages/example/src/pages/_app.tsx
@@ -20,6 +20,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         },
       }}
       fallback={<ConnectButton />}
+      loading={null}
     >
       <Suspense fallback="Loading...">
         <RequireNetwork chainId={1337} fallback={<SwitchNetwork />}>

--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -9,7 +9,7 @@ import {
   useBalance,
   Contract,
   ContractTransaction,
-  useLogout,
+  useDisconnectWallet,
 } from "ethereal-react";
 import { TechStackList } from "../components/TechStackList";
 import TechStackDeployment from "../../deployments/localhost/TechStack.json";
@@ -66,10 +66,8 @@ function Minter({ contract }: { contract: Contract }) {
   );
 }
 
-console.log(TechStackDeployment);
-
 export default function App() {
-  const logout = useLogout();
+  const disconnect = useDisconnectWallet();
   const [block] = useBlock();
   const balance = useBalance();
   const TechStack = useContract(TechStackDeployment.address, [
@@ -83,7 +81,7 @@ export default function App() {
       <div>Balance: {balance.toString()}</div>
       <TechStackList />
       <Minter contract={TechStack} />
-      <button onClick={logout}>Logout</button>
+      <button onClick={disconnect}>Disconnect</button>
     </div>
   );
 }

--- a/packages/website/docs/getting-started/connecting-wallet.md
+++ b/packages/website/docs/getting-started/connecting-wallet.md
@@ -66,17 +66,17 @@ function App() {
 }
 ```
 
-## Logging Out (Disconnect Wallet)
+## Disconnect the Wallet (logging out)
 
-When your user has connected their wallet to your app, you may want to allow them to disconnect their wallet. This is done through the `useLogout` hook. This hook must be rendered within the `WalletProvider` component.
+When your user has connected their wallet to your app, you may want to allow them to disconnect their wallet. This is done through the `useDisconnectWallet` hook. This hook must be rendered within the `WalletProvider` component.
 
 ```tsx
-import { useLogout } from "ethereal-react";
+import { useDisconnectWallet } from "ethereal-react";
 
-function LogoutButton() {
-  const logout = useLogout();
-  return <button onClick={logout}>Logout</button>;
+function DisconnectButton() {
+  const disconnect = useDisconnectWallet();
+  return <button onClick={disconnect}>Disconnect</button>;
 }
 ```
 
-When the logout button is clicked, the `fallback` of the `WalletProvider` will be rendered. If the `cachedProvider` property is set, then the cached providers will be removed as well.
+When the disconnect button is clicked, the `fallback` of the `WalletProvider` will be rendered. If the `cachedProvider` property is set, then the cached providers will be removed as well.


### PR DESCRIPTION
This fixes #45 #44, and partially #42.

While I was here, I also added a new `loading` prop that lets you control the state during the initialization of the wallet provider. This makes it easy to avoid the flash of the fallback prop during startup.