### PR TITLE
`useENSForAddress`: Remove duplicate resolve name check

### DIFF
--- a/packages/ethereal-react/src/ens.ts
+++ b/packages/ethereal-react/src/ens.ts
@@ -15,17 +15,7 @@ export function useResolveENS(ensName: string) {
 
 const ensForAddressAsset = createAsset(
   async (provider: EtherealProvider, address: string) => {
-    // NOTE: Reverse resolution is not always accurate, so we need to perform
-    // the reverse lookup, then the normal lookup to verify that they point
-    // to the same address.
-    // This is taken from these docs: https://docs.ens.domains/dapp-developer-guide/resolving-names#reverse-resolution
-    const ensName = await provider.lookupAddress(address);
-    const resolvedAddress = await provider.resolveName(ensName);
-    if (resolvedAddress === address) {
-      return ensName;
-    }
-
-    return null;
+    return await provider.lookupAddress(address);
   }
 );
 


### PR DESCRIPTION
I am still getting this error in the latest version while using `useENSForAddress` for wallets/addresses without a corresponding ENS name:

![image](https://user-images.githubusercontent.com/508855/138582813-64abc63f-7008-4158-892a-c04faea72ff3.png)

I think this is because, if `provider.lookupAddress` returns `null`, we pass that back into `provider.resolveName`, which expects a string, not null. We could bail out at this point, but I was doing some digging in the provider code anyway, and found that the internals already do this check for us, so we don't need to do it:
https://github.com/ethers-io/ethers.js/blob/b1458989761c11bf626591706aa4ce98dae2d6a9/packages/providers/src.ts/base-provider.ts#L1728-L1729